### PR TITLE
Remove version number

### DIFF
--- a/IDZSwiftCommonCrypto.podspec
+++ b/IDZSwiftCommonCrypto.podspec
@@ -68,7 +68,7 @@ Pod::Spec.new do |s|
   if [ ! -e CommonCrypto ]; then 
     pwd
     echo Running GenerateCommonCryptoModule
-    ./GenerateCommonCryptoModule iphonesimulator9.1 .  
+    ./GenerateCommonCryptoModule iphonesimulator .
   else 
     echo Skipped GenerateCommonCryptoModule 
   fi


### PR DESCRIPTION
This might fix the issue #10 .
xcrun --sdk \<SDK name\> takes SDK name without a version number(?)
Take a look when you have time.
Thanks :smile: