### PR TITLE
Use salt as an array of bytes instead of String

### DIFF
--- a/DemoPlayground.playground/section-1.swift
+++ b/DemoPlayground.playground/section-1.swift
@@ -31,7 +31,8 @@ sha1String
 
 // MARK: - Key Digest Demo
 // Data from RFC 6070
-let tests = [ ("password", arrayFromString("salt"), 1, 20, "0c60c80f961f0e71f3a9b524af6012062fe037a6")]
+let tests = [ ("password", "salt", 1, 20, "0c60c80f961f0e71f3a9b524af6012062fe037a6"),
+              ("password", arrayFromString("salt"), 1, 20, "0c60c80f961f0e71f3a9b524af6012062fe037a6")]
 for (password, salt, rounds, dkLen, expected) in tests
 {
     let key = PBKDF.deriveKey(password, salt: salt, prf: .SHA1, rounds: uint(rounds), derivedKeyLength: UInt(dkLen))

--- a/DemoPlayground.playground/section-1.swift
+++ b/DemoPlayground.playground/section-1.swift
@@ -31,7 +31,7 @@ sha1String
 
 // MARK: - Key Digest Demo
 // Data from RFC 6070
-let tests = [ ("password", "salt", 1, 20, "0c60c80f961f0e71f3a9b524af6012062fe037a6")]
+let tests = [ ("password", arrayFromString("salt"), 1, 20, "0c60c80f961f0e71f3a9b524af6012062fe037a6")]
 for (password, salt, rounds, dkLen, expected) in tests
 {
     let key = PBKDF.deriveKey(password, salt: salt, prf: .SHA1, rounds: uint(rounds), derivedKeyLength: UInt(dkLen))

--- a/IDZSwiftCommonCrypto/KeyDerivation.swift
+++ b/IDZSwiftCommonCrypto/KeyDerivation.swift
@@ -62,6 +62,28 @@ public class PBKDF
     /// Derives key material from a password and salt.
     ///
     /// -parameter password: the password string, will be converted using UTF8
+    /// -parameter salt: the salt string will be converted using UTF8
+    /// -parameter prf: the pseudo random function
+    /// -parameter round: the number of rounds
+    /// -parameter derivedKeyLength: the length of the desired derived key, in bytes.
+    /// -returns: the derived key
+    ///
+    public class func deriveKey(password : String, salt : String, prf: PseudoRandomAlgorithm, rounds: uint, derivedKeyLength: UInt) -> [UInt8]
+    {
+        var derivedKey = Array<UInt8>(count:Int(derivedKeyLength), repeatedValue: 0)
+        let status : Int32 = CCKeyDerivationPBKDF(CCPBKDFAlgorithm(kCCPBKDF2), password, password.lengthOfBytesUsingEncoding(NSUTF8StringEncoding), salt, salt.lengthOfBytesUsingEncoding(NSUTF8StringEncoding), prf.nativeValue(), rounds, &derivedKey, derivedKey.count)
+        if(status != Int32(kCCSuccess))
+        {
+            NSLog("ERROR: CCKeyDerivationPBDK failed with stats \(status).")
+            fatalError("ERROR: CCKeyDerivationPBDK failed.")
+        }
+        return derivedKey
+    }
+    
+    ///
+    /// Derives key material from a password and salt.
+    ///
+    /// -parameter password: the password string, will be converted using UTF8
     /// -parameter salt: the salt array of bytes
     /// -parameter prf: the pseudo random function
     /// -parameter round: the number of rounds

--- a/IDZSwiftCommonCrypto/KeyDerivation.swift
+++ b/IDZSwiftCommonCrypto/KeyDerivation.swift
@@ -62,16 +62,16 @@ public class PBKDF
     /// Derives key material from a password and salt.
     ///
     /// -parameter password: the password string, will be converted using UTF8
-    /// -parameter salt: the salt string will be converted using UTF8
+    /// -parameter salt: the salt array of bytes
     /// -parameter prf: the pseudo random function
     /// -parameter round: the number of rounds
     /// -parameter derivedKeyLength: the length of the desired derived key, in bytes.
     /// -returns: the derived key
     ///
-    public class func deriveKey(password : String, salt : String, prf: PseudoRandomAlgorithm, rounds: uint, derivedKeyLength: UInt) -> [UInt8]
+    public class func deriveKey(password : String, salt : [UInt8], prf: PseudoRandomAlgorithm, rounds: uint, derivedKeyLength: UInt) -> [UInt8]
     {
         var derivedKey = Array<UInt8>(count:Int(derivedKeyLength), repeatedValue: 0)
-        let status : Int32 = CCKeyDerivationPBKDF(CCPBKDFAlgorithm(kCCPBKDF2), password, password.lengthOfBytesUsingEncoding(NSUTF8StringEncoding), salt, salt.lengthOfBytesUsingEncoding(NSUTF8StringEncoding), prf.nativeValue(), rounds, &derivedKey, derivedKey.count)
+        let status : Int32 = CCKeyDerivationPBKDF(CCPBKDFAlgorithm(kCCPBKDF2), password, password.lengthOfBytesUsingEncoding(NSUTF8StringEncoding), salt, salt.count, prf.nativeValue(), rounds, &derivedKey, derivedKey.count)
         if(status != Int32(kCCSuccess))
         {
             NSLog("ERROR: CCKeyDerivationPBDK failed with stats \(status).")

--- a/IDZSwiftCommonCrypto/Utilities.swift
+++ b/IDZSwiftCommonCrypto/Utilities.swift
@@ -56,7 +56,8 @@ public func arrayFromHexString(s : String) -> [UInt8]
 ///
 public func arrayFromString(s : String) -> [UInt8]
 {
-    return s.utf8.map { UInt8($0.value) }
+    let array = [UInt8](s.utf8)
+    return array
 }
 
 ///

--- a/IDZSwiftCommonCrypto/Utilities.swift
+++ b/IDZSwiftCommonCrypto/Utilities.swift
@@ -49,6 +49,17 @@ public func arrayFromHexString(s : String) -> [UInt8]
 }
 
 ///
+/// Converts a Swift UTF-8 String to a Swift array.
+///
+/// - parameter s: the string
+/// - returns: a Swift array
+///
+public func arrayFromString(s : String) -> [UInt8]
+{
+    return s.utf8.map { UInt8($0.value) }
+}
+
+///
 /// Converts a string of hexadecimal digits to an `NSData` object.
 ///
 /// - parameter s: the hex string (must contain an even number of digits)

--- a/IDZSwiftCommonCryptoTests/IDZSwiftCommonCryptoTests.swift
+++ b/IDZSwiftCommonCryptoTests/IDZSwiftCommonCryptoTests.swift
@@ -471,12 +471,12 @@ class IDZSwiftCommonCryptoTests: XCTestCase {
     // See: https://www.ietf.org/rfc/rfc6070.txt
     func test_KeyDerivation_deriveKey()
     {        
-        let tests = [ ("password", "salt", 1, 20, "0c60c80f961f0e71f3a9b524af6012062fe037a6"),
-            ("password", "salt", 2, 20, "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957"),
-            ("password", "salt", 4096, 20, "4b007901b765489abead49d926f721d065a429c1"),
+        let tests = [ ("password", arrayFromString("salt"), 1, 20, "0c60c80f961f0e71f3a9b524af6012062fe037a6"),
+            ("password", arrayFromString("salt"), 2, 20, "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957"),
+            ("password", arrayFromString("salt"), 4096, 20, "4b007901b765489abead49d926f721d065a429c1"),
 //            ("password", "salt", 16777216, 20, "eefe3d61cd4da4e4e9945b3d6ba2158c2634e984"),
-            ("passwordPASSWORDpassword", "saltSALTsaltSALTsaltSALTsaltSALTsalt", 4096, 25, "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038"),
-            ("pass\0word", "sa\0lt", 4096, 16, "56fa6aa75548099dcc37d7f03425e0c3"),
+            ("passwordPASSWORDpassword", arrayFromString("saltSALTsaltSALTsaltSALTsaltSALTsalt"), 4096, 25, "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038"),
+            ("pass\0word", arrayFromString("sa\0lt"), 4096, 16, "56fa6aa75548099dcc37d7f03425e0c3"),
         ]
         for (password, salt, rounds, dkLen, expected) in tests
         {

--- a/IDZSwiftCommonCryptoTests/IDZSwiftCommonCryptoTests.swift
+++ b/IDZSwiftCommonCryptoTests/IDZSwiftCommonCryptoTests.swift
@@ -470,15 +470,32 @@ class IDZSwiftCommonCryptoTests: XCTestCase {
     // MARK: - KeyDerivation tests
     // See: https://www.ietf.org/rfc/rfc6070.txt
     func test_KeyDerivation_deriveKey()
-    {        
-        let tests = [ ("password", arrayFromString("salt"), 1, 20, "0c60c80f961f0e71f3a9b524af6012062fe037a6"),
+    {
+        // Tests with String salt
+        let tests = [ ("password", "salt", 1, 20, "0c60c80f961f0e71f3a9b524af6012062fe037a6"),
+            ("password", "salt", 2, 20, "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957"),
+            ("password", "salt", 4096, 20, "4b007901b765489abead49d926f721d065a429c1"),
+//            ("password", "salt", 16777216, 20, "eefe3d61cd4da4e4e9945b3d6ba2158c2634e984"),
+            ("passwordPASSWORDpassword", "saltSALTsaltSALTsaltSALTsaltSALTsalt", 4096, 25, "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038"),
+            ("pass\0word", "sa\0lt", 4096, 16, "56fa6aa75548099dcc37d7f03425e0c3"),
+        ]
+        for (password, salt, rounds, dkLen, expected) in tests
+        {
+            let key = PBKDF.deriveKey(password, salt: salt, prf: .SHA1, rounds: uint(rounds), derivedKeyLength: UInt(dkLen))
+            let keyString = hexStringFromArray(key)
+            
+            XCTAssertEqual(key, arrayFromHexString(expected), "Obtained correct key (\(keyString) == \(expected)")
+        }
+        
+        // Tests with Array salt
+        let tests2 = [ ("password", arrayFromString("salt"), 1, 20, "0c60c80f961f0e71f3a9b524af6012062fe037a6"),
             ("password", arrayFromString("salt"), 2, 20, "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957"),
             ("password", arrayFromString("salt"), 4096, 20, "4b007901b765489abead49d926f721d065a429c1"),
 //            ("password", "salt", 16777216, 20, "eefe3d61cd4da4e4e9945b3d6ba2158c2634e984"),
             ("passwordPASSWORDpassword", arrayFromString("saltSALTsaltSALTsaltSALTsaltSALTsalt"), 4096, 25, "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038"),
             ("pass\0word", arrayFromString("sa\0lt"), 4096, 16, "56fa6aa75548099dcc37d7f03425e0c3"),
         ]
-        for (password, salt, rounds, dkLen, expected) in tests
+        for (password, salt, rounds, dkLen, expected) in tests2
         {
             let key = PBKDF.deriveKey(password, salt: salt, prf: .SHA1, rounds: uint(rounds), derivedKeyLength: UInt(dkLen))
             let keyString = hexStringFromArray(key)

--- a/README.playground/section-17.swift
+++ b/README.playground/section-17.swift
@@ -1,4 +1,4 @@
-let keys6 = PBKDF.deriveKey("password", salt: "salt", prf: .SHA1, rounds: 1, derivedKeyLength: 20)
+let keys6 = PBKDF.deriveKey("password", salt: arrayFromString("salt"), prf: .SHA1, rounds: 1, derivedKeyLength: 20)
 // RFC 6070 - Should derive 0c60c80f961f0e71f3a9b524af6012062fe037a6
 let expectedRFC6070 = arrayFromHexString("0c60c80f961f0e71f3a9b524af6012062fe037a6")
 assert(keys6 == expectedRFC6070)


### PR DESCRIPTION
Use salt as an array of bytes instead of String. Also added arrayFromString to ease use of existing code samples.

Note: it's my first pull request. Sorry if I'm messing something.