### PR TITLE
Cocoapods : Fix Warning link to non existant path

### DIFF
--- a/IDZSwiftCommonCrypto.podspec
+++ b/IDZSwiftCommonCrypto.podspec
@@ -41,8 +41,8 @@ CMD
 
   # Make sure we can find the dummy frameworks
   s.xcconfig = { 
-  "SWIFT_INCLUDE_PATHS" => "$(PROJECT_DIR)/IDZSwiftCommonCrypto/Frameworks/$(PLATFORM_NAME)",
-  "FRAMEWORK_SEARCH_PATHS" => "$(PROJECT_DIR)/IDZSwiftCommonCrypto/Frameworks/$(PLATFORM_NAME)"
+  "SWIFT_INCLUDE_PATHS" => "${PODS_ROOT}/IDZSwiftCommonCrypto/Frameworks/$(PLATFORM_NAME)",
+  "FRAMEWORK_SEARCH_PATHS" => "${PODS_ROOT}/IDZSwiftCommonCrypto/Frameworks/$(PLATFORM_NAME)"
   }
 
 end


### PR DESCRIPTION
Using the PODS_ROOT folder instead of PROJECT_DIR for the Frameworks search path to remove the link warning.