### PR TITLE
Deployment target version set to 9.0

### DIFF
--- a/IDZSwiftCommonCrypto.podspec
+++ b/IDZSwiftCommonCrypto.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.social_media_url   = "http://twitter.com/iOSDevZone"
  
   s.osx.deployment_target = '10.11'
-  s.ios.deployment_target = '9.3'
+  s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 


### PR DESCRIPTION
Not sure why #53 got closed but I tested this change by running all the tests in the example app and pulling it into my project. Everything worked fine as expected. `pod spec lint` passed validation and `pod lib lint` has same issues as 9.3 podspec. 

I'm happy to run any more validations to get this change in. Please let me know

@iosdevzone 