### PR TITLE
Sets APPLICATION_EXTENSION_API_ONLY = YES

### DIFF
--- a/IDZSwiftCommonCrypto.podspec
+++ b/IDZSwiftCommonCrypto.podspec
@@ -48,7 +48,8 @@ CMD
   s.xcconfig = { 
   "SWIFT_VERSION" => "3.0",
   "SWIFT_INCLUDE_PATHS" => "${PODS_ROOT}/IDZSwiftCommonCrypto/Frameworks/$(PLATFORM_NAME)",
-  "FRAMEWORK_SEARCH_PATHS" => "${PODS_ROOT}/IDZSwiftCommonCrypto/Frameworks/$(PLATFORM_NAME)"
+  "FRAMEWORK_SEARCH_PATHS" => "${PODS_ROOT}/IDZSwiftCommonCrypto/Frameworks/$(PLATFORM_NAME)",
+  "APPLICATION_EXTENSION_API_ONLY" => "YES"
   }
 
 end

--- a/IDZSwiftCommonCrypto.podspec
+++ b/IDZSwiftCommonCrypto.podspec
@@ -45,7 +45,7 @@ CMD
   s.preserve_paths = "Frameworks"
 
   # Make sure we can find the dummy frameworks
-  s.xcconfig = { 
+  s.pod_target_xcconfig = {
   "SWIFT_VERSION" => "3.0",
   "SWIFT_INCLUDE_PATHS" => "${PODS_ROOT}/IDZSwiftCommonCrypto/Frameworks/$(PLATFORM_NAME)",
   "FRAMEWORK_SEARCH_PATHS" => "${PODS_ROOT}/IDZSwiftCommonCrypto/Frameworks/$(PLATFORM_NAME)",

--- a/IDZSwiftCommonCrypto.xcodeproj/project.pbxproj
+++ b/IDZSwiftCommonCrypto.xcodeproj/project.pbxproj
@@ -923,6 +923,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -976,6 +977,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_CODE_COVERAGE = NO;


### PR DESCRIPTION
This currently causes a linker warning when using IDZSwiftCommonCrypto in an extension target.