### PR TITLE
Remove some obsoleted constants.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10.1
+osx_image: xcode10.2
 install:
 - npm install -g playground
 

--- a/DemoPlayground.playground/Contents.swift
+++ b/DemoPlayground.playground/Contents.swift
@@ -17,7 +17,7 @@ var md5String = hexString(fromArray: digest)
 
 s.MD5
 
-// MARK: - HMAC Demogit s
+// MARK: - HMAC Demo
 // Data from RFC 2202
 var key = arrayFrom(hexString: "0102030405060708090a0b0c0d0e0f10111213141516171819")
 var data : [UInt8] = Array(repeating:0xcd, count:50)

--- a/IDZSwiftCommonCrypto.podspec
+++ b/IDZSwiftCommonCrypto.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "IDZSwiftCommonCrypto"
-  s.version      = "0.12.1"
+  s.version      = "0.13.0"
   s.summary      = "A wrapper for Apple's Common Crypto library written in Swift."
 
   s.homepage     = "https://github.com/iosdevzone/IDZSwiftCommonCrypto"

--- a/IDZSwiftCommonCrypto/Status.swift
+++ b/IDZSwiftCommonCrypto/Status.swift
@@ -72,7 +72,7 @@ public enum Status : CCCryptorStatus, CustomStringConvertible, Error
     ///
     public static func fromRaw(status: CCCryptorStatus) -> Status?
     {
-        var from = [ kCCSuccess: success, kCCParamError: paramError,
+        let from = [ kCCSuccess: success, kCCParamError: paramError,
             kCCBufferTooSmall: bufferTooSmall, kCCMemoryFailure: memoryFailure,
             kCCAlignmentError: alignmentError, kCCDecodeError: decodeError, kCCUnimplemented: unimplemented,
             kCCOverflow: overflow, kCCRNGFailure: rngFailure]

--- a/IDZSwiftCommonCrypto/StreamCryptor.swift
+++ b/IDZSwiftCommonCrypto/StreamCryptor.swift
@@ -84,44 +84,38 @@ open class StreamCryptor
 	///
 	/// Enumerates encryption mode
 	///
-	public enum Mode
-	{
+    public enum Mode
+    {
         /// Electronic Code Book
-		case ECB
+        case ECB
         /// Cipher Block Chaining
-		case CBC
+        case CBC
         /// Cipher FeeBack
-		case CFB
+        case CFB
         /// Counter
-		case CTR
-        /// Unimplemented for now (not included)
-		case F8	//		= 5, // Unimplemented for now (not included)
-        /// Unimplemented for now (not included)
-		case LRW//		= 6, // Unimplemented for now (not included)
+        case CTR
         /// Output FeedBack
-		case OFB
-        /// Xor-encode-xor Tweaked with ciphertext Stealing
-		case XTS
+        case OFB
         /// RC4 streaming
-		case RC4
+        case RC4
         /// Cipher FeebBack with 8-bit shifts
-		case CFB8
-		
-		func nativeValue() -> CCMode {
-			switch self {
-			case .ECB : return CCMode(kCCModeECB)
-			case .CBC : return CCMode(kCCModeCBC)
-			case .CFB : return CCMode(kCCModeCFB)
-			case .CTR : return CCMode(kCCModeCTR)
-			case .F8 : return CCMode(kCCModeF8)// Unimplemented for now (not included)
-			case .LRW : return CCMode(kCCModeLRW)// Unimplemented for now (not included)
-			case .OFB : return CCMode(kCCModeOFB)
-			case .XTS : return CCMode(kCCModeXTS)
-			case .RC4 : return CCMode(kCCModeRC4)
-			case .CFB8 : return CCMode(kCCModeCFB8)
-			}
-		}
+        case CFB8
         
+        
+        /// Obtain the native value for a Mode.
+        func nativeValue() -> CCMode {
+            switch self {
+            case .ECB : return CCMode(kCCModeECB)
+            case .CBC : return CCMode(kCCModeCBC)
+            case .CFB : return CCMode(kCCModeCFB)
+            case .CTR : return CCMode(kCCModeCTR)
+            case .OFB : return CCMode(kCCModeOFB)
+            case .RC4 : return CCMode(kCCModeRC4)
+            case .CFB8 : return CCMode(kCCModeCFB8)
+            }
+        }
+        
+        /// Returns true if this `Mode` requires an initialization vector.
         func requiresInitializationVector() -> Bool {
             switch self {
             case .ECB:
@@ -130,7 +124,7 @@ open class StreamCryptor
                 return true;
             }
         }
-	}
+    }
 	
 	/**
 	 Enumerated encryption paddings

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Which version you use depends on which version of Xcode and Swift you are curren
 * 0.10.x -- Xcode 9.0, Swift 4.0
 * 0.11.x -- Xcode 10.0, Swift 4.2
 * 0.12.x -- Xcode 10.2, Swift 5.0
+* 0.13.x -- Xcode 11.0, Swift 5.1, iOS 13.0
 
 Using `Digest`
 --------------

--- a/README.playground/Contents.swift
+++ b/README.playground/Contents.swift
@@ -20,6 +20,8 @@ import IDZSwiftCommonCrypto
  Using `Digest`
  --------------
  
+ * Note: The code below uses MD5 for demonstration purposes because it generates short digests, however, it is considered cryptographically broken and new code should use at least SHA256.
+ 
  To calculate a message digest you create an instance of `Digest`, call `update` one or more times with the data over which the digest is being calculated and finally call `final` to obtain the digest itself.
  
  The `update` method can take a `String`
@@ -63,11 +65,11 @@ var digests4 = Digest(algorithm: .md5).update(s)?.final() // digest is of type [
  ### Supported Algorithms
  The `Digest` class supports the following algorithms:
  
- * `.md2`
- * `.md4`
- * `.md5`
- * `.sha1`
- * `.sha224`
+ * `.md2` -- insecure and should not be used in new code.
+ * `.md4` -- insecure and should not be used in new code.
+ * `.md5` -- insecure and should not be used in new code.
+ * `.sha1` -- insecure and should not be used in new code.
+ * `.sha224` -- insecure and should not be used in new code.
  * `.sha256`
  * `.sha384`
  * `.sha512`
@@ -89,9 +91,9 @@ assert(hmacs5! == expectedRFC2202)
 /*: 
  
  ### Supported Algorithms
- * `.md5`
- * `.sha1`
- * `.sha224`
+ * `.md5` -- insecure and should not be used in new code.
+ * `.sha1` -- insecure and should not be used in new code.
+ * `.sha224` -- insecure and should not be used in new code.
  * `.sha256`
  * `.sha384`
  * `.sha512`

--- a/README.playground/contents.xcplayground
+++ b/README.playground/contents.xcplayground
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='macos' allows-reset='true' display-mode='raw'/>
+<playground version='6.0' target-platform='macos' allows-reset='true' display-mode='rendered'/>


### PR DESCRIPTION
This is a tentative fix for issue #99. 

Apple has removed the following mode constants from CommonCrypto:

* `kCCModeF8`
* `KCCModeLRW`
* `kCCModeXTS`

The former two were not actually implemented in CommonCrypto according to comments in the header file. The latter was implemented, as far as I know, but IDZSwiftCommonCrypto never exposed some other constants that would have been needed to use it correctly, so essentially I don't think this will break anyone's code.