### PR TITLE
Revert watchos deployment target version

### DIFF
--- a/IDZSwiftCommonCrypto.podspec
+++ b/IDZSwiftCommonCrypto.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.11'
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
-  s.watchos.deployment_target = '5.1'
+  s.watchos.deployment_target = '2.0'
 
   s.source       = { :git => "https://github.com/iosdevzone/IDZSwiftCommonCrypto.git", :tag => s.version.to_s }
 


### PR DESCRIPTION
With an ios target of 9.0, a watchos target of 5.1 isn't necessary, and limits use of the library