### PR TITLE
Improved `StreamCryptor` demo showing IV handling.

### DIFF
--- a/README.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/README.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/README.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/README.playground/playground.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
There seems to be some confusion about how to deal with initialization vectors and to be quite honest the demo code was pretty bad. This pull request updates the runnable demo in README.playground and replicates it in README.md. 