### PR TITLE
Add SwiftPM support

### DIFF
--- a/IDZSwiftCommonCrypto.xcworkspace/contents.xcworkspacedata
+++ b/IDZSwiftCommonCrypto.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:Package.swift">
+   </FileRef>
+   <FileRef
       location = "group:DemoPlayground.playground">
    </FileRef>
    <FileRef

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,7 @@ let package = Package(
     targets: [
         .target(
             name: "IDZSwiftCommonCrypto",
-            dependencies: []),
-        .testTarget(
-            name: "IDZSwiftCommonCryptoTests",
-            dependencies: ["IDZSwiftCommonCrypto"]),
+            dependencies: [],
+            path: "IDZSwiftCommonCrypto"),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "IDZSwiftCommonCrypto",
+    products: [
+        .library(
+            name: "IDZSwiftCommonCrypto",
+            targets: ["IDZSwiftCommonCrypto"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "IDZSwiftCommonCrypto",
+            dependencies: []),
+        .testTarget(
+            name: "IDZSwiftCommonCryptoTests",
+            dependencies: ["IDZSwiftCommonCrypto"]),
+    ]
+)


### PR DESCRIPTION
This seems to have been really simple. By just adding a Package.swift file to the repo, and pointing my Xcode project to that tagged commit (which Xcode lists as a proper version number), my project imports IDZSwiftCommonCrypto just fine, sans Cocoapods!

I didn't point Package.swift to the test files, but it shouldn't be too much harder to do.